### PR TITLE
String explicit cast

### DIFF
--- a/src/all/apt/File.h
+++ b/src/all/apt/File.h
@@ -48,7 +48,7 @@ public:
 	// Append _size bytes from _data to the internal buffer. If _data is 0 the internal buffer is reallocated.
 	void        appendData(const char* _data, uint64 _size);
 
-	const char* getPath() const                                 { return m_path; }
+	const char* getPath() const                                 { return (const char*)m_path; }
 	void        setPath(const char* _path)                      { m_path.set(_path); }
 	const char* getData() const                                 { return m_data; }
 	char*       getData()                                       { return m_data; }

--- a/src/all/apt/FileSystem.cpp
+++ b/src/all/apt/FileSystem.cpp
@@ -12,7 +12,7 @@ using namespace apt;
 
 const char* FileSystem::GetRoot(RootType _type)
 {
-	return s_roots[_type];
+	return (const char*)s_roots[_type];
 }
 
 void FileSystem::SetRoot(RootType _type, const char* _path)
@@ -60,7 +60,7 @@ void FileSystem::StripRoot(StringBase& ret_, const char* _path)
 		if (s_rootLengths[r] == 0) {
 			continue;
 		}
-		const char* rootBeg = strstr(_path, s_roots[r]);
+		const char* rootBeg = strstr(_path, (const char*)s_roots[r]);
 		if (rootBeg != nullptr) {
 			ret_.set(rootBeg + s_rootLengths[r] + 1);
 			return;
@@ -140,7 +140,7 @@ void FileSystem::MakePath(StringBase& ret_, const char* _path, RootType _root)
 	bool useRoot = !s_roots[_root].isEmpty() && !IsAbsolute(_path);
 	if (useRoot) {
 	 // check if the root already exists in path as a directory
-		const char* r = strstr(s_roots[_root], _path);
+		const char* r = strstr((const char*)s_roots[_root], _path);
 		if (!r || *(r + s_rootLengths[_root]) != s_separator) {
 			ret_.setf("%s%c%s", (const char*)s_roots[_root], s_separator, _path);
 			return;

--- a/src/all/apt/FileSystem.h
+++ b/src/all/apt/FileSystem.h
@@ -63,7 +63,7 @@ public:
 
 	// Make _path relative to _root. It is safe for _path to point to the string buffer in ret_.
 	static void        MakeRelative(StringBase& ret_, const char* _path, RootType _root = RootType_Root);
-	static void        MakeRelative(StringBase& ret_, RootType _root = RootType_Root) { MakeRelative(ret_, ret_, _root); }
+	static void        MakeRelative(StringBase& ret_, RootType _root = RootType_Root) { MakeRelative(ret_, (const char*)ret_, _root); }
 	
 	// Return true if _path is absolute.
 	static bool        IsAbsolute(const char* _path);
@@ -71,21 +71,21 @@ public:
 	// Strip path from _path up to and including any root directory. It is safe for _path to point to 
 	// the string buffer in ret_.
 	static void        StripRoot(StringBase& ret_, const char* _path);
-	static void        StripRoot(StringBase& ret_) { StripRoot(ret_, ret_); }
+	static void        StripRoot(StringBase& ret_) { StripRoot(ret_, (const char*)ret_); }
 	// Strip path from _path. It is safe for _path to point to the string buffer in ret_.
 	static void        StripPath(StringBase& ret_, const char* _path);
-	static void        StripPath(StringBase& ret_) { StripPath(ret_, ret_); }
+	static void        StripPath(StringBase& ret_) { StripPath(ret_, (const char*)ret_); }
 
 	// Extract path from _path (remove file name + extension). It is safe for _path to point
 	// the string buffer in ret_.
 	static void        GetPath(StringBase& ret_, const char* _path);
-	static void        GetPath(StringBase& ret_) { GetFileName(ret_, ret_); }
+	static void        GetPath(StringBase& ret_) { GetFileName(ret_, (const char*)ret_); }
 	// Extract file name from _path. It is safe for _path to point to the string buffer in ret_.
 	static void        GetFileName(StringBase& ret_, const char* _path);
-	static void        GetFileName(StringBase& ret_) { GetFileName(ret_, ret_); }
+	static void        GetFileName(StringBase& ret_) { GetFileName(ret_, (const char*)ret_); }
 	// Extract extension from _path. It is safe for _path to point to the string buffer in ret_.
 	static void        GetExtension(StringBase& ret_, const char* _path) { ret_.set(FindExtension(_path)); }
-	static void        GetExtension(StringBase& ret_) { GetExtension(ret_, ret_); }
+	static void        GetExtension(StringBase& ret_) { GetExtension(ret_, (const char*)ret_); }
 
 	// Return ptr to the character following the last occurrence of '.' in _path.
 	static const char* FindExtension(const char* _path);

--- a/src/all/apt/Json.cpp
+++ b/src/all/apt/Json.cpp
@@ -834,7 +834,7 @@ template <> bool JsonSerializer::value<StringBase>(const char* _name, StringBase
 		int ln = string(_name, 0);
 		_value_.setCapacity(ln + 1);
 	}
-	return string(_name, _value_) != 0;
+	return string(_name, (char*)_value_) != 0;
 }
 
 template <> bool JsonSerializer::value<StringBase>(StringBase& _value_)
@@ -847,7 +847,7 @@ template <> bool JsonSerializer::value<StringBase>(StringBase& _value_)
 		}
 		_value_.setCapacity(ln + 1);
 	}
-	return string(_value_) != 0;
+	return string((char*)_value_) != 0;
 }
 
 int JsonSerializer::string(const char* _name, char* _string_)

--- a/src/all/apt/String.cpp
+++ b/src/all/apt/String.cpp
@@ -17,6 +17,9 @@ using namespace apt;
 
 uint StringBase::set(const char* _src, uint _count)
 {
+	if (!_src) {
+		return 0;
+	}
 	uint len = strlen(_src);
 	len = (_count == 0) ? len : APT_MIN(len, _count);
 	len += 1;
@@ -190,7 +193,15 @@ uint StringBase::getLength() const
 
 bool StringBase::operator==(const char* _rhs) const
 {
-	return strcmp(_rhs, m_buf) == 0;
+	return strcmp(m_buf, _rhs) == 0;
+}
+bool StringBase::operator<(const char* _rhs) const
+{
+	return strcmp(m_buf, _rhs) < 0;
+}
+bool StringBase::operator>(const char* _rhs) const
+{
+	return strcmp(m_buf, _rhs) > 0;
 }
 
 void StringBase::setCapacity(uint _capacity)

--- a/src/all/apt/String.h
+++ b/src/all/apt/String.h
@@ -48,7 +48,7 @@ public:
 
 	// Replace all instances of _find with _replace. Return the number of instances replaced.
 	uint replace(char _find, char _replace); // single char (faster, in-place)
-	uint replace(const char* _find, const char* _replace); // sub string
+	uint replace(const char* _find, const char* _replace); // substring
 
 	// Convert to upper/lower case.
 	void toUpperCase();
@@ -58,27 +58,27 @@ public:
 	// \note String length is not stored internally, hence getLength() is not a constant time operation.
 	uint getLength() const;
 
-	void clear()                                { if (m_buf) { *m_buf = '\0'; } }
-	bool isEmpty() const                        { return m_buf ? *m_buf == '\0' : true; }
-	bool isLocal() const                        { return m_buf == getLocalBuf(); }
-	uint getCapacity() const                    { return m_capacity; }
+	void clear()                                   { if (m_buf) { *m_buf = '\0'; } }
+	bool isEmpty() const                           { return m_buf ? *m_buf == '\0' : true; }
+	bool isLocal() const                           { return m_buf == getLocalBuf(); }
+	uint getCapacity() const                       { return m_capacity; }
 	void setCapacity(uint _capacity);
 
 	bool operator==(const char* _rhs) const;
-	bool operator==(const StringBase& _rhs) const  { return this->operator==(m_buf); }
+	bool operator==(const StringBase& _rhs) const  { return this->operator==((const char*)_rhs); }
 	bool operator<(const char* _rhs) const;
-	bool operator<(const StringBase& _rhs) const   { return this->operator<(m_buf); }
+	bool operator<(const StringBase& _rhs) const   { return this->operator<((const char*)_rhs); }
 	bool operator>(const char* _rhs) const;
-	bool operator>(const StringBase& _rhs) const   { return this->operator>(m_buf); }
+	bool operator>(const StringBase& _rhs) const   { return this->operator>((const char*)_rhs); }
 
 	// Cast to char*/const char* is explicit to avoid conflicts with the operator overloads above.
 	explicit operator const char*() const          { return m_buf; }
 	explicit operator char*()                      { return m_buf; }
+	const char* c_str() const                      { return m_buf; }
 	
 	friend void swap(StringBase& _a_, StringBase& _b_);
 
 protected:
-	
 	// String always heap-allocated.
 	StringBase();
 	// String has a local buffer of _localBufferSize chars.

--- a/src/all/apt/String.h
+++ b/src/all/apt/String.h
@@ -58,15 +58,22 @@ public:
 	// \note String length is not stored internally, hence getLength() is not a constant time operation.
 	uint getLength() const;
 
-	void clear()                                { *m_buf = '\0'; }
-	bool isEmpty() const                        { return *m_buf == '\0'; }
+	void clear()                                { if (m_buf) { *m_buf = '\0'; } }
+	bool isEmpty() const                        { return m_buf ? *m_buf == '\0' : true; }
 	bool isLocal() const                        { return m_buf == getLocalBuf(); }
 	uint getCapacity() const                    { return m_capacity; }
 	void setCapacity(uint _capacity);
 
 	bool operator==(const char* _rhs) const;
-	operator const char*() const                { return m_buf; }
-	operator char*()                            { return m_buf; }
+	bool operator==(const StringBase& _rhs) const  { return this->operator==(m_buf); }
+	bool operator<(const char* _rhs) const;
+	bool operator<(const StringBase& _rhs) const   { return this->operator<(m_buf); }
+	bool operator>(const char* _rhs) const;
+	bool operator>(const StringBase& _rhs) const   { return this->operator>(m_buf); }
+
+	// Cast to char*/const char* is explicit to avoid conflicts with the operator overloads above.
+	explicit operator const char*() const          { return m_buf; }
+	explicit operator char*()                      { return m_buf; }
 	
 	friend void swap(StringBase& _a_, StringBase& _b_);
 
@@ -107,8 +114,8 @@ class String: public StringBase
 
 public:
 	String():                              StringBase(kCapacity)           {}
-	String(const String<kCapacity>& _rhs): StringBase(kCapacity)           { set(_rhs); }
-	String<kCapacity>& operator=(const String<kCapacity>& _rhs)            { if (&_rhs != this) set(_rhs); return *this; }
+	String(const String<kCapacity>& _rhs): StringBase(kCapacity)           { set((const char*)_rhs); }
+	String<kCapacity>& operator=(const String<kCapacity>& _rhs)            { if (&_rhs != this) set((const char*)_rhs); return *this; }
 	String(String<kCapacity>&& _rhs):      StringBase((StringBase&&)_rhs)  {}
 	String<kCapacity>& operator=(String<kCapacity>&& _rhs)                 { StringBase::operator=((StringBase&&)_rhs); return *this; }
 	String(const char* _fmt, ...):         StringBase(kCapacity)
@@ -127,10 +134,10 @@ class String<0>: public StringBase
 {
 public:
 	String():                      StringBase()                   {}
-	String(const String<0>& _rhs): StringBase()                   { set(_rhs); }
-	String<0>& operator=(const String<0>& _rhs)                   { if (&_rhs != this) set(_rhs); return *this; }
+	String(const String<0>& _rhs): StringBase()                   { set((const char*)_rhs); }
+	String<0>& operator=(const String<0>& _rhs)                   { if (&_rhs != this) set((const char*)_rhs); return *this; }
 	String(String<0>&& _rhs):      StringBase((StringBase&&)_rhs) {}
-	String<0>& operator=(String<0>&& _rhs)                        { (String<0>)StringBase::operator=((StringBase&&)_rhs); return *this; }
+	String<0>& operator=(String<0>&& _rhs)                        { StringBase::operator=((StringBase&&)_rhs); return *this; }
 	String(const char* _fmt, ...): StringBase()
 	{
 		if (_fmt) {

--- a/src/all/apt/TextParser.h
+++ b/src/all/apt/TextParser.h
@@ -53,7 +53,7 @@ public:
 	// Return true if the region between _beg and the current position exactly matches _str.
 	bool matches(const char *_beg, const char* _str);
 
-	// Advance to the next occurrence of substring _str, return true if found, else false.
+	// Advance to the next occurrence of substring _str, return false if not found.
 	bool find(const char* _str);
 
 	// Return # occurences of '\n' up to and including _pos (or the current position if _pos is 0).

--- a/src/all/apt/Time.cpp
+++ b/src/all/apt/Time.cpp
@@ -20,5 +20,5 @@ const char* Timestamp::asString() const
 			s_buf.setf("%1.0fus", x);
 		}
 	}
-	return s_buf;
+	return (const char*)s_buf;
 }

--- a/src/all/apt/log.cpp
+++ b/src/all/apt/log.cpp
@@ -15,7 +15,7 @@ static void DispatchLogCallback(const char* _fmt, va_list _args, LogType _type)
 	if (g_logCallback) {
 		String<kLogMsgMax> buf;
 		buf.setfv(_fmt, _args);
-		g_logCallback(buf, _type);
+		g_logCallback((const char*)buf, _type);
 	}
 }
 

--- a/src/win/apt/FileSystemImpl.cpp
+++ b/src/win/apt/FileSystemImpl.cpp
@@ -90,7 +90,7 @@ DateTime FileSystem::GetTimeCreated(const char* _path, RootType _rootHint)
 		return DateTime(); // \todo return invalid sentinel
 	}
 	DateTime created, modified;
-	GetFileDateTime(fullPath, created, modified);
+	GetFileDateTime((const char*)fullPath, created, modified);
 	return created;
 }
 
@@ -101,7 +101,7 @@ DateTime FileSystem::GetTimeModified(const char* _path, RootType _rootHint)
 		return DateTime(); // \todo return invalid sentinel
 	}
 	DateTime created, modified;
-	GetFileDateTime(fullPath, created, modified);
+	GetFileDateTime((const char*)fullPath, created, modified);
 	return modified;
 }
 
@@ -115,7 +115,7 @@ void FileSystem::MakeRelative(StringBase& ret_, const char* _path, RootType _roo
 		APT_PLATFORM_VERIFY(GetFullPathName(tmp, MAX_PATH, root, NULL)); // required to resolve a relative path (e.g. when launching from the ide)
 		char* pathEnd = strrchr(root, (int)'\\');
 		++pathEnd;
-		strcpy(pathEnd, s_roots[_root]);
+		strcpy(pathEnd, (const char*)s_roots[_root]);
 	}
  // construct the full path
 	TCHAR path[MAX_PATH] = {};
@@ -266,7 +266,7 @@ bool FileSystem::CreateDir(const char* _path)
 	while (tp.advanceToNext("\\/") != 0) {
 		String<64> mkdir;
 		mkdir.set(_path, tp.getCharCount());
-		if (CreateDirectory(mkdir, NULL) == 0) {
+		if (CreateDirectory((const char*)mkdir, NULL) == 0) {
 			DWORD err = GetLastError();
 			if (err != ERROR_ALREADY_EXISTS) {
 				APT_LOG_ERR("CreateDirectory(%s): %s", _path, GetPlatformErrorString(err));

--- a/src/win/apt/TimeImpl.cpp
+++ b/src/win/apt/TimeImpl.cpp
@@ -132,6 +132,6 @@ const char* apt::DateTime::asString(const char* _format) const
 			}
 		}
 	}
-	return s_buf;
+	return (const char*)s_buf;
 }
 

--- a/tests/String_tests.cpp
+++ b/tests/String_tests.cpp
@@ -5,6 +5,7 @@
 #include <apt/String.h>
 
 #include <EASTL/vector.h>
+#include <EASTL/vector_map.h>
 
 using namespace apt;
 
@@ -33,11 +34,31 @@ static void VectorTest()
 	}
 }
 
-TEST_CASE("Vector", "[String]")
+
+TEST_CASE("vector", "[String]")
 {
 	VectorTest<0>();
 	VectorTest<16>();
 	VectorTest<64>();
+}
+
+TEST_CASE("vector_map", "[String]")
+{
+ // test use of String in a dictionary
+	typedef String<16> Str;
+	typedef eastl::vector_map<Str, Str> StrMap;
+
+	StrMap map;
+
+	map.insert(eastl::make_pair(Str("Key A"), Str("Value A")));
+	REQUIRE(map.find("Key A") != map.end());
+	REQUIRE(map.find("Key A")->second == "Value A");
+	REQUIRE(map.find("abc") == map.end());
+
+	map.insert(eastl::make_pair(Str("Key B"), Str("Value B")));
+	REQUIRE(map.find("Key B") != map.end());
+	REQUIRE(map.find("Key B")->second == "Value B");
+	REQUIRE(map.find("abc") == map.end());
 }
 
 TEST_CASE("toUpperCase, toLowerCase", "[String]")
@@ -46,7 +67,15 @@ TEST_CASE("toUpperCase, toLowerCase", "[String]")
 	static const char* upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
 	String<0> str(lower);
 	str.toUpperCase();
-	REQUIRE((str == upper) == true);
+	REQUIRE(str == upper);
 	str.toLowerCase();
-	REQUIRE((str == lower) == true);
+	REQUIRE(str == lower);
+}
+
+TEST_CASE("relational operators", "[String]")
+{
+	typedef String<16> Str;
+	REQUIRE(Str("abc") < Str("xyz"));
+	REQUIRE(Str("xyz") > Str("abc"));
+	REQUIRE(Str("abc") == Str("abc"));
 }


### PR DESCRIPTION
Implicit cast from `String` -> `const char*` was causing some hard-to-find bugs and making operator overloading unusable.