### PR TITLE
Fix I/O for DDS volumetric textures.

### DIFF
--- a/src/all/extern/dds.cpp
+++ b/src/all/extern/dds.cpp
@@ -663,9 +663,10 @@ bool Image::ReadDds(Image& img_, const char* _data, uint _dataSize)
 		const char* src = _data + doff;
 		char* dst = img_.m_data;
 		for (unsigned i = 0; i < img_.m_mipmapCount; ++i) {
-			memcpy(dst, src, img_.m_mipSizes[i]);
-			dst += img_.m_mipSizes[i];
-			src += img_.m_mipSizes[i];
+			const auto mipSize = img_.m_mipSizes[i];
+			memcpy(dst, src, mipSize);
+			dst += mipSize;
+			src += mipSize;
 		}
 	} else {
 	 // non-3d textures are stored slice-wise (all mips for slice0 followed by all mips for slice1, etc).
@@ -845,11 +846,12 @@ bool Image::WriteDds(File& file_, const Image& _img)
 	dst = buf + sizeof(DWORD) + sizeof(DDS_HEADER) + sizeof(DDS_HEADER_DXT10);
 	if (_img.m_depth > 1 && _img.m_mipmapCount > 1) {
 	 // 3d textures are stored mip-wise (all slices for mip0 followed by all slices for mip1, etc).
-		src = _img.m_data + _img.m_mipOffsets[0];
+		src = _img.m_data;
 		for (unsigned i = 0; i < _img.m_mipmapCount; ++i) {
-			memcpy(dst, src, _img.m_mipSizes[i]);
-			src += _img.m_mipSizes[i];
-			dst += _img.m_mipSizes[i];
+			const auto mipSize = _img.m_mipSizes[i];
+			memcpy(dst, src, mipSize);
+			dst += mipSize;
+			src += mipSize;
 		}
 	} else {
 	 // non-3d textures are stored slice-wise (all mips for slice0 followed by all mips for slice1, etc).

--- a/src/all/extern/dds.cpp
+++ b/src/all/extern/dds.cpp
@@ -660,15 +660,12 @@ bool Image::ReadDds(Image& img_, const char* _data, uint _dataSize)
 	unsigned doff = sizeof(DWORD) + sizeof(DDS_HEADER) + (dxt10h ? sizeof(DDS_HEADER_DXT10) : 0);
 	if (img_.m_depth > 1 && img_.m_mipmapCount > 1) {
 	 // 3d textures are stored mip-wise (all slices for mip0 followed by all slices for mip1, etc).
-		const char* src = _data + doff + img_.m_mipSizes[0];
+		const char* src = _data + doff;
+		char* dst = img_.m_data;
 		for (unsigned i = 0; i < img_.m_mipmapCount; ++i) {
-			char* dst = img_.m_data;
-			dst += i > 0 ? img_.m_mipSizes[i - 1] : 0;
-			for (unsigned j = 0; j < img_.m_depth; ++j) {
-				memcpy(dst, src, img_.m_mipSizes[i]);
-				src += img_.m_mipSizes[i];
-				dst += img_.m_arrayLayerSize;
-			}
+			memcpy(dst, src, img_.m_mipSizes[i]);
+			dst += img_.m_mipSizes[i];
+			src += img_.m_mipSizes[i];
 		}
 	} else {
 	 // non-3d textures are stored slice-wise (all mips for slice0 followed by all mips for slice1, etc).
@@ -848,13 +845,11 @@ bool Image::WriteDds(File& file_, const Image& _img)
 	dst = buf + sizeof(DWORD) + sizeof(DDS_HEADER) + sizeof(DDS_HEADER_DXT10);
 	if (_img.m_depth > 1 && _img.m_mipmapCount > 1) {
 	 // 3d textures are stored mip-wise (all slices for mip0 followed by all slices for mip1, etc).
+		src = _img.m_data + _img.m_mipOffsets[0];
 		for (unsigned i = 0; i < _img.m_mipmapCount; ++i) {
-			src = _img.m_data;
-			src += i > 0 ? _img.m_mipSizes[i - 1] : 0;
-			for (unsigned j = 0; j < _img.m_depth; ++j) {
-				memcpy(dst, src, _img.m_mipSizes[i]);
-				dst += _img.m_arrayLayerSize;
-			}
+			memcpy(dst, src, _img.m_mipSizes[i]);
+			src += _img.m_mipSizes[i];
+			dst += _img.m_mipSizes[i];
 		}
 	} else {
 	 // non-3d textures are stored slice-wise (all mips for slice0 followed by all mips for slice1, etc).


### PR DESCRIPTION
This PR fix the loading and writing of mip-mapped volumetric texture.

Previously the destination addresses were moving for the entire space of the texture data (_one layer of a one cell array_) instead of the current mip data bytesize.